### PR TITLE
Add MongoDB connection setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb+srv://bun:YKeSKo6f1Iwp08D1@cluster0.qkefk1s.mongodb.net/

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
+    "mongoose": "^7.6.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,88 @@
+/* eslint-env node */
+import http, { IncomingMessage, ServerResponse } from "http";
+import type { Model } from "mongoose";
+import { connectToDatabase } from "../src/lib/db";
+import { Product } from "./models/Product";
+import { Order } from "./models/Order";
+import { User } from "./models/User";
+import { Promotion } from "./models/Promotion";
+import { Coupon } from "./models/Coupon";
+
+const models: Record<string, Model<unknown>> = {
+  products: Product,
+  orders: Order,
+  users: User,
+  promotions: Promotion,
+  coupons: Coupon,
+};
+
+const getBody = (req: IncomingMessage): Promise<string> => {
+  return new Promise((resolve) => {
+    let data = "";
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => resolve(data));
+  });
+};
+
+const sendJson = (res: ServerResponse, data: unknown, status = 200) => {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+  res.end(JSON.stringify(data));
+};
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    sendJson(res, { error: "Invalid request" }, 400);
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const [, api, resource, id] = url.pathname.split("/");
+
+  if (req.method === "OPTIONS") {
+    sendJson(res, {});
+    return;
+  }
+
+  if (api !== "api" || !resource || !models[resource]) {
+    sendJson(res, { error: "Not found" }, 404);
+    return;
+  }
+
+  await connectToDatabase();
+  const Model = models[resource];
+
+  try {
+    if (req.method === "GET") {
+      if (id) {
+        const doc = await Model.findById(id).lean();
+        sendJson(res, doc);
+      } else {
+        const docs = await Model.find().lean();
+        sendJson(res, docs);
+      }
+    } else if (req.method === "POST") {
+      const body = await getBody(req);
+      const created = await Model.create(JSON.parse(body || "{}"));
+      sendJson(res, created, 201);
+    } else if (req.method === "PUT" && id) {
+      const body = await getBody(req);
+      const updated = await Model.findByIdAndUpdate(id, JSON.parse(body || "{}"), { new: true }).lean();
+      sendJson(res, updated);
+    } else if (req.method === "DELETE" && id) {
+      await Model.findByIdAndDelete(id);
+      sendJson(res, { success: true });
+    } else {
+      sendJson(res, { error: "Method not allowed" }, 405);
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    sendJson(res, { error: message }, 500);
+  }
+});
+
+server.listen(3000);

--- a/server/models/Coupon.ts
+++ b/server/models/Coupon.ts
@@ -1,0 +1,13 @@
+/* eslint-env node */
+import { Schema, model, models } from "mongoose";
+
+const couponSchema = new Schema(
+  {
+    code: { type: String, required: true, unique: true },
+    discount: { type: Number, required: true },
+    expiresAt: Date,
+  },
+  { timestamps: true }
+);
+
+export const Coupon = models.Coupon || model("Coupon", couponSchema);

--- a/server/models/Order.ts
+++ b/server/models/Order.ts
@@ -1,0 +1,14 @@
+/* eslint-env node */
+import { Schema, model, models, Types } from "mongoose";
+
+const orderSchema = new Schema(
+  {
+    user: { type: Types.ObjectId, ref: "User", required: true },
+    products: [{ type: Types.ObjectId, ref: "Product", required: true }],
+    total: { type: Number, required: true },
+    status: { type: String, default: "pending" },
+  },
+  { timestamps: true }
+);
+
+export const Order = models.Order || model("Order", orderSchema);

--- a/server/models/Product.ts
+++ b/server/models/Product.ts
@@ -1,0 +1,13 @@
+/* eslint-env node */
+import { Schema, model, models } from "mongoose";
+
+const productSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    description: String,
+    price: { type: Number, required: true },
+  },
+  { timestamps: true }
+);
+
+export const Product = models.Product || model("Product", productSchema);

--- a/server/models/Promotion.ts
+++ b/server/models/Promotion.ts
@@ -1,0 +1,15 @@
+/* eslint-env node */
+import { Schema, model, models } from "mongoose";
+
+const promotionSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    description: String,
+    discount: { type: Number, required: true },
+    startDate: Date,
+    endDate: Date,
+  },
+  { timestamps: true }
+);
+
+export const Promotion = models.Promotion || model("Promotion", promotionSchema);

--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,0 +1,12 @@
+/* eslint-env node */
+import { Schema, model, models } from "mongoose";
+
+const userSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+  },
+  { timestamps: true }
+);
+
+export const User = models.User || model("User", userSchema);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,20 @@
+/* eslint-env node */
+/// <reference types="node" />
+import mongoose from "mongoose";
+
+let connection: typeof mongoose | null = null;
+
+export const connectToDatabase = async (): Promise<typeof mongoose> => {
+  if (connection) {
+    return connection;
+  }
+
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error("MONGODB_URI is not defined");
+  }
+
+  await mongoose.connect(uri);
+  connection = mongoose;
+  return mongoose;
+};


### PR DESCRIPTION
## Summary
- add MongoDB connection string in `.env`
- add mongoose dependency and connection helper
- add basic HTTP API with CRUD routes for products, orders, users, promotions, and coupons

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7cabcfd54832d8935444dc5b1f1ab