### PR TITLE
Integrate API data across pages

### DIFF
--- a/server/models/Product.ts
+++ b/server/models/Product.ts
@@ -6,11 +6,12 @@ const productSchema = new Schema(
     name: { type: String, required: true },
     description: String,
     price: { type: Number, required: true },
-   codex/add-mongodb-database-connection-mn91pi
     category: { type: String, required: true },
-    codex/add-mongodb-database-connection-32h9cj
-    category: { type: String, required: true },
- main
+    image: String,
+    rating: Number,
+    reviews: Number,
+    inStock: { type: Boolean, default: true },
+    featured: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/src/components/CategoriesSection.tsx
+++ b/src/components/CategoriesSection.tsx
@@ -1,47 +1,57 @@
+import { useEffect, useState, type ComponentType } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ArrowRight, Cookie, Apple, Coffee, Zap } from "lucide-react";
 
+const API_BASE = "http://localhost:3000/api";
+
+interface CategoryInfo {
+  name: string;
+  count: number;
+}
+
+const iconMap: Record<string, { icon: ComponentType<{ className?: string }>; color: string; iconColor: string }> = {
+  Sweet: {
+    icon: Cookie,
+    color: "bg-gradient-to-br from-pink-50 to-orange-50",
+    iconColor: "text-pink-600",
+  },
+  Fruit: {
+    icon: Apple,
+    color: "bg-gradient-to-br from-green-50 to-emerald-50",
+    iconColor: "text-green-600",
+  },
+  Savory: {
+    icon: Coffee,
+    color: "bg-gradient-to-br from-amber-50 to-yellow-50",
+    iconColor: "text-amber-600",
+  },
+  Special: {
+    icon: Zap,
+    color: "bg-gradient-to-br from-purple-50 to-pink-50",
+    iconColor: "text-purple-600",
+  },
+};
+
 const CategoriesSection = () => {
-  const categories = [
-    {
-      id: "sweet",
-      name: "Sweet Buns",
-      description: "Indulgent treats for your sweet tooth",
-      icon: Cookie,
-      count: 18,
-      color: "bg-gradient-to-br from-pink-50 to-orange-50",
-      iconColor: "text-pink-600",
-    },
-    {
-      id: "fruit",
-      name: "Fruit Buns",
-      description: "Fresh fruit-filled delights",
-      icon: Apple,
-      count: 12,
-      color: "bg-gradient-to-br from-green-50 to-emerald-50",
-      iconColor: "text-green-600",
-    },
-    {
-      id: "savory",
-      name: "Savory Buns",
-      description: "Perfect for meals and snacks",
-      icon: Coffee,
-      count: 15,
-      color: "bg-gradient-to-br from-amber-50 to-yellow-50",
-      iconColor: "text-amber-600",
-    },
-    {
-      id: "special",
-      name: "Special Edition",
-      description: "Limited time seasonal favorites",
-      icon: Zap,
-      count: 6,
-      color: "bg-gradient-to-br from-purple-50 to-pink-50",
-      iconColor: "text-purple-600",
-    },
-  ];
+  const [categories, setCategories] = useState<CategoryInfo[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/products`)
+      .then((res) => res.json())
+      .then((products: { category?: string }[]) => {
+        const counts: Record<string, number> = {};
+        products.forEach((p) => {
+          const cat = p.category || "Uncategorized";
+          counts[cat] = (counts[cat] || 0) + 1;
+        });
+        setCategories(
+          Object.entries(counts).map(([name, count]) => ({ name, count }))
+        );
+      })
+      .catch(() => setCategories([]));
+  }, []);
 
   return (
     <section className="py-16 bg-muted/30">
@@ -52,7 +62,7 @@ const CategoriesSection = () => {
             Shop by Category
           </h2>
           <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-            Explore our diverse collection of artisanal buns, each category crafted 
+            Explore our diverse collection of artisanal buns, each category crafted
             with unique flavors and premium ingredients
           </p>
         </div>
@@ -60,32 +70,39 @@ const CategoriesSection = () => {
         {/* Categories Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {categories.map((category) => {
-            const IconComponent = category.icon;
+            const config = iconMap[category.name] || {
+              icon: Cookie,
+              color: "bg-muted",
+              iconColor: "text-foreground",
+            };
+            const IconComponent = config.icon;
             return (
-              <Card 
-                key={category.id} 
+              <Card
+                key={category.name}
                 className="group cursor-pointer border-border/50 hover:border-primary/20 transition-all duration-300 hover:shadow-card hover:-translate-y-1"
               >
                 <CardContent className="p-6">
-                  <div className={`w-16 h-16 rounded-2xl ${category.color} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300`}>
-                    <IconComponent className={`h-8 w-8 ${category.iconColor}`} />
+                  <div
+                    className={`w-16 h-16 rounded-2xl ${config.color} flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300`}
+                  >
+                    <IconComponent className={`h-8 w-8 ${config.iconColor}`} />
                   </div>
-                  
+
                   <h3 className="font-semibold text-lg text-foreground mb-2 group-hover:text-primary transition-colors">
                     {category.name}
                   </h3>
-                  
+
                   <p className="text-muted-foreground text-sm mb-4 leading-relaxed">
-                    {category.description}
+                    {category.count} items available
                   </p>
-                  
+
                   <div className="flex items-center justify-between">
                     <Badge variant="secondary" className="text-xs">
                       {category.count} items
                     </Badge>
-                    <Button 
-                      variant="ghost" 
-                      size="sm" 
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       className="p-0 h-auto text-muted-foreground group-hover:text-primary transition-colors"
                     >
                       <ArrowRight className="h-4 w-4" />
@@ -110,3 +127,4 @@ const CategoriesSection = () => {
 };
 
 export default CategoriesSection;
+

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import ProductCard from "./ProductCard";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -7,52 +8,38 @@ import chocolateBun from "@/assets/chocolate-bun.jpg";
 import blueberryBun from "@/assets/blueberry-bun.jpg";
 import honeyBun from "@/assets/honey-bun.jpg";
 
+const API_BASE = "http://localhost:3000/api";
+const imageMap: Record<string, string> = {
+  Sweet: cinnamonBun,
+  Fruit: blueberryBun,
+  Savory: honeyBun,
+  Special: chocolateBun,
+};
+
+interface Product {
+  _id: string;
+  name: string;
+  price: number;
+  image?: string;
+  rating?: number;
+  reviews?: number;
+  category?: string;
+  inStock?: boolean;
+  featured?: boolean;
+}
+
 const FeaturedProducts = () => {
-  const featuredProducts = [
-    {
-      id: "1",
-      name: "Classic Cinnamon Bun",
-      price: 4.99,
-      image: cinnamonBun,
-      rating: 4.8,
-      reviews: 124,
-      category: "Sweet",
-      inStock: true,
-      featured: true,
-    },
-    {
-      id: "2", 
-      name: "Chocolate Chip Delight",
-      price: 5.49,
-      image: chocolateBun,
-      rating: 4.9,
-      reviews: 89,
-      category: "Sweet",
-      inStock: true,
-      featured: true,
-    },
-    {
-      id: "3",
-      name: "Blueberry Burst",
-      price: 5.29,
-      image: blueberryBun,
-      rating: 4.7,
-      reviews: 156,
-      category: "Fruit",
-      inStock: true,
-      featured: true,
-    },
-    {
-      id: "4",
-      name: "Honey Glazed",
-      price: 4.79,
-      image: honeyBun,
-      rating: 4.6,
-      reviews: 203,
-      category: "Sweet",
-      inStock: false,
-    },
-  ];
+  const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/products?limit=8`)
+      .then((res) => res.json())
+      .then((data: Product[]) => {
+        const fp = data.filter((p) => p.featured);
+        setFeaturedProducts(fp);
+      })
+      .catch(() => setFeaturedProducts([]));
+  }, []);
 
   return (
     <section className="py-16 bg-background">
@@ -78,7 +65,18 @@ const FeaturedProducts = () => {
         {/* Products Grid */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {featuredProducts.map((product) => (
-            <ProductCard key={product.id} {...product} />
+            <ProductCard
+              key={product._id}
+              id={product._id}
+              name={product.name}
+              price={product.price}
+              image={product.image || imageMap[product.category] || cinnamonBun}
+              rating={product.rating || 0}
+              reviews={product.reviews || 0}
+              category={product.category || "Uncategorized"}
+              inStock={product.inStock ?? true}
+              featured={product.featured}
+            />
           ))}
         </div>
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -53,7 +53,7 @@ export const getDbHealth = (): DbHealth => {
     state: stateMap[rs] ?? "DISCONNECTED",
     readyState: rs,
     dbName: mongoose.connection.name,
-    host: (mongoose.connection as any).host,
+    host: (mongoose.connection as { host?: string }).host,
   };
 };
 
@@ -61,17 +61,17 @@ export const getDbHealth = (): DbHealth => {
 export const pingDb = async (): Promise<DbHealth> => {
   try {
     await connectToDatabase();
-    // @ts-ignore
+    // @ts-expect-error - admin is not typed in mongoose connection
     const ping = await mongoose.connection.db.admin().ping();
     return {
       ...getDbHealth(),
       ok: ping?.ok === 1 ? 1 : 0,
     };
-  } catch (e: any) {
+  } catch (e: unknown) {
     return {
       ...getDbHealth(),
       ok: 0,
-      error: e?.message || String(e),
+      error: e instanceof Error ? e.message : String(e),
     };
   }
 };

--- a/src/pages/AdminResource.tsx
+++ b/src/pages/AdminResource.tsx
@@ -165,6 +165,7 @@ const AdminResource = () => {
               </TableRow>
             </TableHeader>
             <TableBody>
+              {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
               {data.map((item: any) => (
                 <TableRow key={item._id}>
                   <TableCell>{item._id}</TableCell>

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 
+const API_BASE = "http://localhost:3000/api";
+
 interface CategoryInfo {
   name: string;
   count: number;
@@ -11,7 +13,7 @@ const Categories = () => {
   const [categories, setCategories] = useState<CategoryInfo[]>([]);
 
   useEffect(() => {
-    fetch("/api/products")
+    fetch(`${API_BASE}/products`)
       .then((res) => res.json())
       .then((products: { category?: string }[]) => {
         const counts: Record<string, number> = {};


### PR DESCRIPTION
## Summary
- enrich product model with image, rating, stock, and featured flags
- update API server to return list data and handle errors robustly
- fetch product/category data from the API across homepage and product listings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c7e0d4710c832da7a82bf5005b40ec