### PR TITLE
Add authentication API and connect login/register

### DIFF
--- a/server/models/User.ts
+++ b/server/models/User.ts
@@ -1,12 +1,67 @@
 /* eslint-env node */
 import { Schema, model, models } from "mongoose";
+import { hashPassword } from "../utils/password";
+
+type Role = "user" | "admin";
 
 const userSchema = new Schema(
   {
-    name: { type: String, required: true },
-    email: { type: String, required: true, unique: true },
+    name: { type: String, required: true, trim: true },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    tel: { type: String, required: true, trim: true },
+    password: { type: String, required: true, minlength: 6, select: false },
+    role: {
+      type: String,
+      enum: ["user", "admin"],
+      default: "user",
+    },
   },
   { timestamps: true }
 );
+
+userSchema.pre("save", function (next) {
+  if (!this.isModified("password")) return next();
+  this.set("password", hashPassword(String(this.get("password"))));
+  next();
+});
+
+type UpdateWithSet = { $set?: Record<string, unknown> } & Record<string, unknown>;
+
+userSchema.pre("findOneAndUpdate", function (next) {
+  const update = this.getUpdate() as UpdateWithSet | undefined;
+  if (!update) return next();
+
+  const set = update.$set ?? update;
+  const pwd = set?.password;
+  if (typeof pwd === "string" && pwd.trim()) {
+    const hashed = hashPassword(pwd);
+    if (update.$set) {
+      update.$set.password = hashed;
+    } else {
+      update.password = hashed;
+    }
+  }
+  next();
+});
+
+const removePassword = (_doc: unknown, ret: Record<string, unknown>) => {
+  delete ret.password;
+  return ret;
+};
+
+userSchema.set("toJSON", { transform: removePassword });
+userSchema.set("toObject", { transform: removePassword });
+
+export type UserDocument = typeof userSchema extends infer T
+  ? T extends Schema<infer U>
+    ? U & { role: Role }
+    : never
+  : never;
 
 export const User = models.User || model("User", userSchema);

--- a/server/utils/password.ts
+++ b/server/utils/password.ts
@@ -1,0 +1,25 @@
+/* eslint-env node */
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+const SALT_LENGTH = 16;
+const KEY_LENGTH = 64;
+
+export const hashPassword = (password: string): string => {
+  const salt = randomBytes(SALT_LENGTH).toString("hex");
+  const derivedKey = scryptSync(password, salt, KEY_LENGTH).toString("hex");
+  return `${salt}:${derivedKey}`;
+};
+
+export const verifyPassword = (password: string, storedHash: string): boolean => {
+  try {
+    const [salt, key] = storedHash.split(":");
+    if (!salt || !key) return false;
+    const hashedBuffer = Buffer.from(key, "hex");
+    const derived = scryptSync(password, salt, KEY_LENGTH);
+    if (hashedBuffer.length !== derived.length) return false;
+    return timingSafeEqual(hashedBuffer, derived);
+  } catch (error) {
+    console.error("Failed to verify password", error);
+    return false;
+  }
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,16 +11,23 @@ const Login = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const { login } = useAuth();
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const loggedIn = login(email, password);
-    if (loggedIn) {
-      navigate(loggedIn.role === "admin" ? "/admin" : "/");
-    } else {
-      setError("Invalid credentials");
+    setError("");
+    setSubmitting(true);
+    try {
+      const result = await login(email, password);
+      if (result.user) {
+        navigate(result.user.role === "admin" ? "/admin" : "/");
+      } else {
+        setError(result.error ?? "Invalid credentials");
+      }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -58,8 +65,12 @@ const Login = () => {
           {error && (
             <p className="text-sm text-destructive text-center">{error}</p>
           )}
-          <Button type="submit" className="w-full bg-gradient-primary hover:opacity-90">
-            Login
+          <Button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-gradient-primary hover:opacity-90"
+          >
+            {submitting ? "Logging in..." : "Login"}
           </Button>
           <p className="text-sm text-center text-muted-foreground">
             Don't have an account? <Link to="/register" className="text-primary">Register</Link>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -14,20 +14,27 @@ const Register = () => {
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const { register } = useAuth();
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError("");
     if (password !== confirm) {
       setError("Passwords do not match");
       return;
     }
-    const success = register(email, name, tel, password);
-    if (success) {
-      navigate("/login");
-    } else {
-      setError("Email already exists");
+    setSubmitting(true);
+    try {
+      const result = await register(email, name, tel, password);
+      if (result.success) {
+        navigate("/login");
+      } else {
+        setError(result.error ?? "Registration failed");
+      }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -93,8 +100,12 @@ const Register = () => {
           {error && (
             <p className="text-sm text-destructive text-center">{error}</p>
           )}
-          <Button type="submit" className="w-full bg-gradient-primary hover:opacity-90">
-            Register
+          <Button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-gradient-primary hover:opacity-90"
+          >
+            {submitting ? "Registering..." : "Register"}
           </Button>
           <p className="text-sm text-center text-muted-foreground">
             Already have an account? <Link to="/login" className="text-primary">Login</Link>


### PR DESCRIPTION
## Summary
- extend the user model with credentials, hashing, and role metadata
- add dedicated /api/auth/register and /api/auth/login endpoints that persist users and validate passwords
- switch the auth context plus login/register screens to call the backend API and handle loading + error states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8da2020ec832d832d9ac51203e05f